### PR TITLE
fix: changes version of peer dependency stylelint so plugin can be in…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "stylelint test/*.scss"
   },
   "peerDependencies": {
-    "stylelint": "~14.5.3"
+    "stylelint": "14.x"
   },
   "stylelint": {
     "extends": "./index.js"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "Android >= 5"
   ],
   "devDependencies": {
-    "stylelint": "14.x"
+    "stylelint": "^14.5.3"
   },
   "keywords": [
     "stylelint",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "Android >= 5"
   ],
   "devDependencies": {
-    "stylelint": "^14.5.3"
+    "stylelint": "14.x"
   },
   "keywords": [
     "stylelint",


### PR DESCRIPTION
## Description

Since @netcentric/stylelint-config is a plugin, peer dependencies should be less strict. Current semver for stylelint allows only to be installed in projects with stylelint version 14.5.3 <14.6.0.

## Related Issue

Fixes #6.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **[CONTRIBUTING](docs/CONTRIBUTING.mnd)** document.
- [x] All new and existing tests passed.
