### PR TITLE
Remove null 'indentation' rule setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = {
     "plugin/no-unsupported-browser-features": [true, { "severity": "warning" }],
 
     // general
-    "indentation": null,
     "no-missing-end-of-source-newline": null,
 
     // vendor prefixes


### PR DESCRIPTION
Remove null 'indentation' rule setting, in order to get right indentation when autofix enabled in stylelint
